### PR TITLE
fix: add rustls-tls to release binary dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,7 @@ uuid = { version = "1", default-features = false, features = ["v4"] }
 metrics = { version = "0.24", default-features = false }
 clap = { version = "4.5", default-features = false, features = ["std", "derive", "help", "usage", "error-context"] }
 opendal = { version = "0.55", default-features = false, features = ["blocking", "services-fs", "services-s3"] }
+reqwest = { version = "0.12", default-features = false, features = ["rustls-tls"] }
 
 [dev-dependencies]
 tempfile = "3.13"


### PR DESCRIPTION
reqwest with rustls-tls was only in [dev-dependencies], so the release binary shipped without any TLS backend. All HTTPS requests (S3, R2) failed with "error sending request for url". Move reqwest to [dependencies] so the TLS connector is included in release builds.